### PR TITLE
Corrigido erro de display nas rich picutres

### DIFF
--- a/docs/Base/1.1.DesignSprint.md
+++ b/docs/Base/1.1.DesignSprint.md
@@ -101,15 +101,7 @@ Nesta etapa, os membros da equipe elaboraram rascunhos e representações visuai
 
 *Figura 1: Rich Picture do ecossistema G7_MonitoreSeuTreino. Autor: [Daniel Teles](https://github.com/dtdanielteles).*
 
-![Rich Picture](../img/rich_picture_giovanni.png)
-*Figura 4: Rich Picture do ecossistema G7_MonitoreSeuTreino. Autor: [Giovanni Dornelas](github.com/GGDornelas).*
-
-
-
-![Rich Picture](../img/rich_picture_lucas.jpeg)
-*Figura 4: Rich Picture do ecossistema G7_MonitoreSeuTreino. Autor: [Lucas Antunes](github.com/LucasAntunes-UNB).*
-
-## Etapa 3 — Decision (Decidir)
+</details>
 
 <details>
 <summary><strong>Andre Meyer</strong> — Rich Picture do ecossistema G7_MonitoreSeuTreino</summary>
@@ -126,6 +118,22 @@ Nesta etapa, os membros da equipe elaboraram rascunhos e representações visuai
 ![Rich Picture - José Victor](../img/rich_picture_jose.jpeg)
 
 *Figura 3: Rich Picture do ecossistema G7_MonitoreSeuTreino. Autor: [José Victor](https://github.com/RR2M4A).*
+
+</details>
+
+<details>
+<summary><strong>Giovanni Dornelas</strong> — Rich Picture do ecossistema G7_MonitoreSeuTreino</summary>
+
+![Rich Picture](../img/rich_picture_giovanni.png)
+*Figura 4: Rich Picture do ecossistema G7_MonitoreSeuTreino. Autor: [Giovanni Dornelas](github.com/GGDornelas).*
+
+</details>
+
+<details>
+<summary><strong>Lucas Antunes</strong> — Rich Picture do ecossistema G7_MonitoreSeuTreino</summary>
+
+![Rich Picture](../img/rich_picture_lucas.jpeg)
+*Figura 4: Rich Picture do ecossistema G7_MonitoreSeuTreino. Autor: [Lucas Antunes](github.com/LucasAntunes-UNB).*
 
 </details>
 


### PR DESCRIPTION
Seções colapsáveis das rich picutres estavam ocultando os tópicos abaixos dela no page 1.1.DesignSprint. Verifique localmente se erro não persiste mais